### PR TITLE
[DPR-576] Fix for certificate DNS being too long

### DIFF
--- a/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
+++ b/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
@@ -12,7 +12,7 @@ generic-service:
   ingress:
     enabled: true
     host: app-hostname.local    # override per environment
-    tlsSecretName: hmpps-digital-prison-reporting-mi-ui-cert
+    tlsSecretName: hmpps-digital-prison-reporting-mi-cert
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Counterpart CPE changes:
- https://github.com/ministryofjustice/cloud-platform-environments/pull/14462
- https://github.com/ministryofjustice/cloud-platform-environments/pull/14458

The UI DNS was too long for a certificate CN field, and the CN field appears to be populated from the first DNS in the k8s Certificate request. By using a single certificate for both the UI and API, I was able to make the UI DNS the second DNS, which is added as a SAN instead of the CN.