### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.3
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.1
   owasp: entur/owasp@0.0.17
 
@@ -45,7 +45,8 @@ jobs:
             export BUILD_NUMBER=${DATE}.${CIRCLE_BUILD_NUM}
             export GIT_REF="$CIRCLE_SHA1"
             npm run record-build-info
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:

--- a/helm_deploy/hmpps-digital-prison-reporting-mi-ui/Chart.yaml
+++ b/helm_deploy/hmpps-digital-prison-reporting-mi-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-digital-prison-reporting-mi-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.6.3
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.2.4

--- a/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
+++ b/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-digital-prison-reporting-mi-ui
 
@@ -6,12 +5,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-digital-prison-reporting-mi-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-digital-prison-reporting-mi-cert
     modsecurity_enabled: true
     modsecurity_audit_enabled: false
@@ -59,59 +58,12 @@ generic-service:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    durham-tees-valley: "51.179.197.1/32"
-    interservfls: "51.179.196.131/32"
-    sodexo1: "80.86.46.16/32"
-    sodexo2: "80.86.46.17/32"
-    sodexo3: "80.86.46.18/32"
-    sodexo4: "51.148.9.201"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webprox23: "195.92.38.23/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
-    g4s-hmp-parc-1: "217.161.76.162/32"
-    g4s-hmp-parc-2: "217.161.76.154/32"
-    azure-landing-zone-public-egress-1: "20.26.11.71/32"
-    azure-landing-zone-public-egress-2: "20.26.11.108/32"
+    hmp-parc-1: 217.161.76.162/32
+    hmp-parc-2: 217.161.76.154/32
+    groups:
+      - internal
+      - prisons
+      - private_prisons
 
 generic-prometheus-alerts:
   targetApplication: hmpps-digital-prison-reporting-mi-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-digital-prison-reporting-mi-ui/values.yaml
 
 generic-service:
@@ -16,35 +15,9 @@ generic-service:
     AUTHORISED_ROLES: ROLE_PRISONS_REPORTING_USER
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
-    circleci-1: "3.228.39.90"
-    circleci-2: "18.213.67.41"
-    circleci-3: "34.194.94.201"
-    circleci-4: "34.194.144.202"
-    circleci-5: "34.197.6.234"
-    circleci-6: "35.169.17.173"
-    circleci-7: "35.174.253.146"
-    circleci-8: "52.3.128.216"
-    circleci-9: "52.4.195.249"
-    circleci-10: "52.5.58.121"
-    circleci-11: "52.21.153.129"
-    circleci-12: "52.72.72.233"
-    circleci-13: "54.92.235.88"
-    circleci-14: "54.161.182.76"
-    circleci-15: "54.164.161.41"
-    circleci-16: "54.166.105.113"
-    circleci-17: "54.167.72.230"
-    circleci-18: "54.172.26.132"
-    circleci-19: "54.205.138.102"
-    circleci-20: "54.208.72.234"
-    circleci-21: "54.209.115.53"
+    groups:
+      - circleci
+      - internal
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-reporting-dev

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-digital-prison-reporting-mi-ui/values.yaml
 
 generic-service:
@@ -16,80 +15,13 @@ generic-service:
     AUTHORISED_ROLES: ROLE_PRISONS_REPORTING_USER
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
-    circleci-1: "3.228.39.90"
-    circleci-2: "18.213.67.41"
-    circleci-3: "34.194.94.201"
-    circleci-4: "34.194.144.202"
-    circleci-5: "34.197.6.234"
-    circleci-6: "35.169.17.173"
-    circleci-7: "35.174.253.146"
-    circleci-8: "52.3.128.216"
-    circleci-9: "52.4.195.249"
-    circleci-10: "52.5.58.121"
-    circleci-11: "52.21.153.129"
-    circleci-12: "52.72.72.233"
-    circleci-13: "54.92.235.88"
-    circleci-14: "54.161.182.76"
-    circleci-15: "54.164.161.41"
-    circleci-16: "54.166.105.113"
-    circleci-17: "54.167.72.230"
-    circleci-18: "54.172.26.132"
-    circleci-19: "54.205.138.102"
-    circleci-20: "54.208.72.234"
-    circleci-21: "54.209.115.53"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    durham-tees-valley: "51.179.197.1/32"
-    interservfls: "51.179.196.131/32"
-    sodexo1: "80.86.46.16/32"
-    sodexo2: "80.86.46.17/32"
-    sodexo3: "80.86.46.18/32"
-    sodexo4: "51.148.9.201"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webprox23: "195.92.38.23/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
-    g4s-hmp-parc-1: "217.161.76.162/32"
-    g4s-hmp-parc-2: "217.161.76.154/32"
-    azure-landing-zone-public-egress-1: "20.26.11.71/32"
-    azure-landing-zone-public-egress-2: "20.26.11.108/32"
+    hmp-parc-1: 217.161.76.162/32
+    hmp-parc-2: 217.161.76.154/32
+    groups:
+      - circleci
+      - internal
+      - prisons
+      - private_prisons
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-reporting-dev


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

3 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `50 => 2 (48 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- fivewells-3
  

- fivewells-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- quantum
  

- quantum_alt
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- durham-tees-valley
  

- interservfls
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `circleci,internal`
- The size of the allowlist defined in this file will change: `29 => 0 (29 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-test.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `circleci,internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `71 => 2 (69 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- fivewells-3
  

- fivewells-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- quantum
  

- quantum_alt
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- durham-tees-valley
  

- interservfls
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  
