### PR TITLE
bump patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/frontend": "^2.1.0",
-        "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.2.0",
+        "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.3.1",
         "agentkeepalive": "^4.5.0",
         "applicationinsights": "^2.9.2",
         "body-parser": "^1.20.2",
@@ -2782,9 +2782,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-digital-prison-reporting-frontend": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-digital-prison-reporting-frontend/-/hmpps-digital-prison-reporting-frontend-3.2.0.tgz",
-      "integrity": "sha512-FbOelv954SOxRYJfwdSv1MEW5t3C1ED7TWAUMUTbPhFa+6LOniXKBbMQP4XNOrktcgqCoi8mHuv4tkZxLKrjwg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-digital-prison-reporting-frontend/-/hmpps-digital-prison-reporting-frontend-3.3.1.tgz",
+      "integrity": "sha512-drb0GPxOA23Do0aXFQlgQNcM6rGG6Dl55TJXNFZ1/0TYg48df01Bk6rTSaoZC03TYY4ArRBwjXLn57MgStB/cw==",
       "dependencies": {
         "agentkeepalive": "^4.5.0",
         "bunyan": "^1.8.15",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^2.1.0",
-    "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.2.0",
+    "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.3.1",
     "agentkeepalive": "^4.5.0",
     "applicationinsights": "^2.9.2",
     "body-parser": "^1.20.2",

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,24 +14,30 @@ export default function routes(services: Services): Router {
   get('/', (req, res) => {
     res.render('pages/card', {
       title: 'Home',
-      cards: [
-        {
-          text: 'Reports',
-          href: '/reports',
-          description: 'View MI reports',
-        },
-      ],
+      cards: {
+        items: [
+          {
+            text: 'Reports',
+            href: '/reports',
+            description: 'View MI reports',
+          },
+        ],
+        variant: 1,
+      },
     })
   })
 
   get('/reports', (req, res) => {
     res.render('pages/card', {
       title: 'Reports',
-      cards: CardUtils.reportDefinitionsToCards(
-        res.locals.definitions,
-        '/reports',
-        getDefinitionsParameters(req.query),
-      ),
+      cards: {
+        items: CardUtils.reportDefinitionsToCards(
+          res.locals.definitions,
+          '/reports',
+          getDefinitionsParameters(req.query),
+        ),
+        variant: 1,
+      },
     })
   })
 

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -33,7 +33,10 @@ export default function routes(router: Router, services: Services) {
     res.render('pages/card', {
       title: reportDefinition.name,
       breadCrumbList: [{ text: 'Reports', href: '/reports' }],
-      cards: CardUtils.variantDefinitionsToCards(reportDefinition, '/reports', getDefinitionsParameters(req.query)),
+      cards: {
+        items: CardUtils.variantDefinitionsToCards(reportDefinition, '/reports', getDefinitionsParameters(req.query)),
+        variant: 1,
+      },
     })
   })
 

--- a/server/views/pages/card.njk
+++ b/server/views/pages/card.njk
@@ -8,7 +8,7 @@
   <h1>{{ title }}</h1>
 
   <div class="govuk-width-container ">
-    {{ dprCardGroup(cards) }}
+    {{ dprCardGroup(cards.items, cards.variant) }}
   </div>
 
 {% endblock %}


### PR DESCRIPTION
- Bump FE lib version "^3.2.0" => "^3.3.1",
- Incorporate card variant id in render options
- Card is currently still original until we have steer on how to use the new variant