### PR TITLE
[DPR2-449] Invalid report/variant ID causes app crash

### DIFF
--- a/cypress-tests/common/pages/ErrorPage.ts
+++ b/cypress-tests/common/pages/ErrorPage.ts
@@ -1,0 +1,7 @@
+import { PageElement } from './page'
+
+export default class ErrorPage {
+  messageHeader = (): PageElement => cy.get('h2')
+
+  statusCodeHeader = (): PageElement => cy.get('h3')
+}

--- a/cypress-tests/integration-tests/e2e/viewReports.cy.ts
+++ b/cypress-tests/integration-tests/e2e/viewReports.cy.ts
@@ -22,7 +22,9 @@ context('View reports', () => {
   it('Report page rejects invalid reportId', () => {
     cy.signIn()
     Page.verifyOnPage(IndexPage)
-    cy.visit('/reports/invalid-report')
+    cy.visit('/reports/invalid-report', {
+      failOnStatusCode: false,
+    })
 
     const errorPage = new ErrorPage()
     errorPage.messageHeader().should('contain.text', 'Unrecognised report ID "invalid-report"')
@@ -32,7 +34,9 @@ context('View reports', () => {
   it('Report page rejects invalid reportId', () => {
     cy.signIn()
     Page.verifyOnPage(IndexPage)
-    cy.visit('/reports/invalid-report/last-year')
+    cy.visit('/reports/invalid-report/last-year', {
+      failOnStatusCode: false,
+    })
 
     const errorPage = new ErrorPage()
     errorPage.messageHeader().should('contain.text', 'Unrecognised report ID "invalid-report"')
@@ -42,7 +46,9 @@ context('View reports', () => {
   it('Report page rejects invalid variantId', () => {
     cy.signIn()
     Page.verifyOnPage(IndexPage)
-    cy.visit('/reports/external-movements/last-year')
+    cy.visit('/reports/external-movements/last-year', {
+      failOnStatusCode: false,
+    })
 
     const errorPage = new ErrorPage()
     errorPage.messageHeader().should('contain.text', 'Unrecognised variant ID "last-year"')

--- a/cypress-tests/integration-tests/e2e/viewReports.cy.ts
+++ b/cypress-tests/integration-tests/e2e/viewReports.cy.ts
@@ -1,6 +1,7 @@
 import IndexPage from '../../common/pages'
 import Page from '../../common/pages/page'
 import ReportsPage from '../../common/pages/ReportsPage'
+import ErrorPage from '../../common/pages/ErrorPage'
 
 context('View reports', () => {
   beforeEach(() => {
@@ -16,5 +17,15 @@ context('View reports', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.reportsCard().click()
     Page.verifyOnPage(ReportsPage)
+  })
+
+  it('Report page reports invalid reportId', () => {
+    cy.signIn()
+    Page.verifyOnPage(IndexPage)
+    cy.visit('/reports/invalid-report')
+
+    const errorPage = new ErrorPage()
+    errorPage.messageHeader().should('contain.text', 'Unrecognised report ID "invalid-report"')
+    errorPage.statusCodeHeader().should('contain.text', '404')
   })
 })

--- a/cypress-tests/integration-tests/e2e/viewReports.cy.ts
+++ b/cypress-tests/integration-tests/e2e/viewReports.cy.ts
@@ -19,13 +19,33 @@ context('View reports', () => {
     Page.verifyOnPage(ReportsPage)
   })
 
-  it('Report page reports invalid reportId', () => {
+  it('Report page rejects invalid reportId', () => {
     cy.signIn()
     Page.verifyOnPage(IndexPage)
     cy.visit('/reports/invalid-report')
 
     const errorPage = new ErrorPage()
     errorPage.messageHeader().should('contain.text', 'Unrecognised report ID "invalid-report"')
+    errorPage.statusCodeHeader().should('contain.text', '404')
+  })
+
+  it('Report page rejects invalid reportId', () => {
+    cy.signIn()
+    Page.verifyOnPage(IndexPage)
+    cy.visit('/reports/invalid-report/last-year')
+
+    const errorPage = new ErrorPage()
+    errorPage.messageHeader().should('contain.text', 'Unrecognised report ID "invalid-report"')
+    errorPage.statusCodeHeader().should('contain.text', '404')
+  })
+
+  it('Report page rejects invalid variantId', () => {
+    cy.signIn()
+    Page.verifyOnPage(IndexPage)
+    cy.visit('/reports/external-movements/last-year')
+
+    const errorPage = new ErrorPage()
+    errorPage.messageHeader().should('contain.text', 'Unrecognised variant ID "last-year"')
     errorPage.statusCodeHeader().should('contain.text', '404')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/frontend": "^2.1.0",
-        "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.5.1",
+        "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.5.2",
         "agentkeepalive": "^4.5.0",
         "applicationinsights": "^2.9.2",
         "body-parser": "^1.20.2",
@@ -2782,9 +2782,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-digital-prison-reporting-frontend": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-digital-prison-reporting-frontend/-/hmpps-digital-prison-reporting-frontend-3.5.1.tgz",
-      "integrity": "sha512-RFw70QzuZiy/IApzu2M67I0ivN07iJPgRPDgE1nK+/7pUlb2sgdt7AXFoa1pTEJ/QLOOmWJNjV6OzlxO+iPoYA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-digital-prison-reporting-frontend/-/hmpps-digital-prison-reporting-frontend-3.5.2.tgz",
+      "integrity": "sha512-ZdZhlVW/9+e6BIrDGSMUj2yq0Ok0SRQVvAcVxeJtSMdbzzGPKGw+riBABiLpFHLkjiLmcfivdedcWJYZkPxbjw==",
       "dependencies": {
         "agentkeepalive": "^4.5.0",
         "bunyan": "^1.8.15",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^2.1.0",
-    "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.5.1",
+    "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.5.2",
     "agentkeepalive": "^4.5.0",
     "applicationinsights": "^2.9.2",
     "body-parser": "^1.20.2",

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -1,12 +1,5 @@
-import type { Express } from 'express'
 import request from 'supertest'
 import { appWithAllRoutes } from './routes/testutils/appSetup'
-
-let app: Express
-
-beforeEach(() => {
-  app = appWithAllRoutes({})
-})
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -14,7 +7,7 @@ afterEach(() => {
 
 describe('GET 404', () => {
   it('should render content with stack in dev mode', () => {
-    return request(app)
+    return request(appWithAllRoutes({}))
       .get('/unknown')
       .expect(404)
       .expect('Content-Type', /html/)

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -2,6 +2,8 @@ import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
 
+export const USER_MESSAGE_PREFIX = 'User:'
+
 export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
     logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error)
@@ -11,9 +13,14 @@ export default function createErrorHandler(production: boolean) {
       return res.redirect('/sign-out')
     }
 
-    res.locals.message = production
-      ? 'Something went wrong. The error has been logged. Please try again'
-      : error.message
+    if (error.message.startsWith(USER_MESSAGE_PREFIX)) {
+      res.locals.message = error.message.replace(USER_MESSAGE_PREFIX, '')
+    } else {
+      res.locals.message = production
+        ? 'Something went wrong. The error has been logged. Please try again'
+        : error.message
+    }
+
     res.locals.status = error.status
     res.locals.stack = production ? null : error.stack
 

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -5,8 +5,8 @@
 
 {% block content %}
 
-  <h1>{{ message }}</h1>
-  <h2>{{ status }}</h2>
+  <h2>{{ message }}</h2>
+  <h3>{{ status }}</h3>
   <pre>{{ stack }}</pre>
 
 {% endblock %}


### PR DESCRIPTION
- Added test coverage.
- Added ability to present certain error messages to user.
- Added validation for report and variant ID before sending to API.