### PR TITLE
Dpr2 911 consumer roles sign out issue

### DIFF
--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -8,14 +8,9 @@ export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
     logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error)
 
-    if (error.status === 401) {
+    if (error.status === 401 || error.status === 403) {
       logger.info('Logging user out')
       return res.redirect('/sign-out')
-    }
-
-    if (error.status === 403) {
-      logger.info('Logging user out')
-      return res.redirect('/authError')
     }
 
     if (error.message.startsWith(USER_MESSAGE_PREFIX)) {

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -8,9 +8,14 @@ export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
     logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error)
 
-    if (error.status === 401 || error.status === 403) {
+    if (error.status === 401) {
       logger.info('Logging user out')
       return res.redirect('/sign-out')
+    }
+
+    if (error.status === 403) {
+      logger.info('Logging user out')
+      return res.redirect('/authError')
     }
 
     if (error.message.startsWith(USER_MESSAGE_PREFIX)) {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -25,7 +25,7 @@ export default function populateCurrentUser(
         }
       }
       res.locals.user = { ...req.session.userDetails, ...res.locals.user }
-      if (userService.userIsUnathorisedByRole(res.locals.user.roles)) {
+      if (req.session.userDetails && userService.userIsUnathorisedByRole(res.locals.user.roles)) {
         return res.redirect('/roleError')
       }
       return next()

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -23,7 +23,10 @@ export default class UserService {
   async getUser(token: string): Promise<UserDetails> {
     const user = await this.hmppsManageUsersClient.getUser(token)
     const roles = await this.hmppsManageUsersClient.getUserRoles(token)
-    const activeCaseLoadId = await this.userClient.getActiveCaseload(token)
+    let activeCaseLoadId
+    if (!this.userIsUnathorisedByRole(roles)) {
+      activeCaseLoadId = await this.userClient.getActiveCaseload(token)
+    }
     return {
       ...user,
       displayName: convertToTitleCase(user.name),


### PR DESCRIPTION
Fix the prevent user from being logged out if unauthorised by role.

- Check user details exist before checking roles are valid and rediredcting
- Don't call  getActiveCaseload if roles are invalid