### PR TITLE
DPR2-2697 increase modSecurity threshold from 5 to 6

### DIFF
--- a/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
+++ b/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
@@ -26,6 +26,8 @@ generic-service:
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking.
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      # Increase anomaly threshold from 5 originally as due to recent ModSec upgrade the rules are stricter with more false positives 
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     annotations:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
       nginx.ingress.kubernetes.io/proxy-body-size: 100m


### PR DESCRIPTION
The 406 response is coming from Nginx as modSecurity is blocking the requests to execute certain reports and dashboards.

The request to execute a dashboard is a POST request from a form with request headers:

content-type application/x-www-form-urlencoded

Modsecurity cannot parse this as JSON and its regex matching rules trigger a false positive as it is a big escaped string (which contains the json) are likely to show it as a violation match due to that.

With these changes the ModSec threshold is increased from 5 to 6 to attempt to bypass this issue.