### PR TITLE
DPR2-2723 updated also main with inbound_anomaly_score_threshold to 50

### DIFF
--- a/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
+++ b/helm_deploy/hmpps-digital-prison-reporting-mi-ui/values.yaml
@@ -27,7 +27,7 @@ generic-service:
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       # Increase anomaly threshold from 5 originally as due to recent ModSec upgrade the rules are stricter with more false positives 
-      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=50"
     annotations:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
       nginx.ingress.kubernetes.io/proxy-body-size: 100m


### PR DESCRIPTION
This change is in all environments but was applied as a hotfix on top of the previous release.
These changes apply the threshold increase also to main.
In this way the lower environments can have the latest main as they did but with the fix applied.